### PR TITLE
Allow interface to be defined more than once 

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -82,6 +82,7 @@ define network::interface (
 
   $enable          = true,
   $template        = "network/interface/${::osfamily}.erb",
+  $interface       = $name,
 
   $enable_dhcp     = false,
 

--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -1,11 +1,11 @@
 # Interface <%= @name %>
 <% if @auto -%>
-auto <%= @name %>
+auto <%= @interface %>
 <% end -%>
-<% if @aallow_hotplug -%>
-allow-hotplug <%= @allow_hotplug %>
+<% if @allow_hotplug -%>
+allow-hotplug <%= @interface %>
 <% end -%>
-<%= @stanza %> <%= @name %> <%= @family %> <%= @manage_method %>
+<%= @stanza %> <%= @interface %> <%= @family %> <%= @manage_method %>
 <% if @manage_address -%>
     address <%= @manage_address %>
 <% end -%>

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -1,5 +1,5 @@
 # File Managed by Puppet
-DEVICE="<%= @name %>"
+DEVICE="<%= @interface %>"
 BOOTPROTO="<%= @manage_bootproto %>"
 ONBOOT="<%= @manage_onboot %>"
 TYPE="<%= @type %>"


### PR DESCRIPTION
Add interface to interface hash, so as to allow defining the same
interface multiple times, which is necessary for example to define
different families (inet and inet6) in Debian.

with the following in hiera:

```
network:
  eth0_v4:
    interface: eth0
    ipaddress: 1.2.3.4
    netmask: 255.255.255.192
    gateway: 1.2.3.1
    family: inet
  eth0_v6:
    interface: eth0
    ipaddress: 3ffe::1
    netmask: 64
```

 the result would look like:

```
# cat /etc/network/interfaces 
# Interface lo
auto lo
iface lo inet loopback
# Interface eth0_v4
auto eth0
iface eth0 inet static
    address 1.2.3.4
    netmask 255.255.255.192
    gateway 1.2.3.1
# Interface eth0_v6
auto eth0
iface eth0 inet6 static
    address 3ffe::1
    netmask 64
```

Also, the 'allow-hotplug' bit was wrong and had a typo so would never show up in the conf.
