### PR TITLE
Add missing broadcast address in Debian interfaces.

### DIFF
--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -18,6 +18,9 @@ allow-hotplug <%= @interface %>
 <% if @network -%>
     network <%= @network %>
 <% end -%>
+<% if @broadcast -%>
+    broadcast <%= @broadcast %>
+<% end -%>
 <% if @metric -%>
     metric <%= @metric %>
 <% end -%>


### PR DESCRIPTION
I found this piece missing.
