### PR TITLE
Support `bond-primary` option for bonding devices

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -154,6 +154,7 @@ define network::interface (
   $bond_downdelay  = undef,
   $bond_updelay    = undef,
   $bond_master     = undef,
+  $bond_primary    = undef,
   $bond_slaves     = undef,
 
   # For bridging

--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -144,6 +144,9 @@ allow-hotplug <%= @interface %>
 <% if @bond_master -%>
     bond-master <%= @bond_master %>
 <% end -%>
+<% if @bond_primary -%>
+    bond-primary <%= @bond_primary %>
+<% end -%>
 <% if @bond_slaves -%>
     bond-slaves <%= @bond_slaves %>
 <% end -%>


### PR DESCRIPTION
- If you're using a system with upstart `bond-primary` is required on each interface that is added to bond
- https://www.kernel.org/doc/Documentation/networking/bonding.txt (See: Example Configurations)
