### PR TITLE
Add vlan-raw-device option to interface (Debian)

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -138,6 +138,7 @@ define network::interface (
   $media           = undef,
   $accept_ra       = undef,
   $autoconf        = undef,
+  $vlan_raw_device = undef,
 
   # Common ifupdown scripts
   $up              = [ ],

--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -96,6 +96,9 @@ allow-hotplug <%= @interface %>
 <% if @autoconf -%>
     autoconf <%= @autoconf %>
 <% end -%>
+<% if @vlan_raw_device -%>
+    vlan-raw-device <%= @vlan_raw_device -%>
+<% end -%>
 <% if @up.length > 0 then -%>
 <% @up.each do |script| -%>
     up <%= script %>


### PR DESCRIPTION
Add "vlan-raw-device" option to Debian interface template.

As described in documentation if you are NOT using interface name like "ethX.Y" but "vlanY"  (where  Y is VLAN ID) you need to provide physical interface to use with vlan-raw-device option.

https://wiki.debian.org/NetworkConfiguration#Howto_use_vlan_.28dot1q.2C_802.1q.2C_trunk.29_.28Etch.2C_Lenny.29
