### PR TITLE
Add an exec resource to set properly hostname on Rhel 7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,7 @@ class network (
       undef   => $interfaces_hash,
       default => $hiera_interfaces_hash,
     }
-  
+
     $hiera_routes_hash = hiera_hash("${module_name}::routes_hash",undef)
     $real_routes_hash = $hiera_routes_hash ? {
       undef   => $routes_hash,
@@ -213,6 +213,15 @@ class network (
       group   => $network::config_file_group,
       content => template($network::hostname_file_template),
       notify  => $network::manage_config_file_notify,
+    }
+    case $::lsbmajdistrelease {
+      '7': {
+        exec { "sethostname":
+          command     => "/usr/bin/hostnamectl set-hostname $manage_hostname",
+          unless      => "/usr/bin/hostnamectl status | grep 'Static hostname: $manage_hostname'",
+        }
+      }
+      default: {}
     }
   }
 


### PR DESCRIPTION
On Rhel 7 set the hostname on files is not enough, so I've added an exec resource that run the new command hostnamectl to set the permanent hostname of the server.
An unless condition should avoid to run it at every run.
