### PR TITLE
Fixed https://github.com/example42/puppet-network/issues/28.

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -203,17 +203,24 @@ define network::interface (
     default => $hwaddr,
   }
 
-  # Debian specific
-  $manage_address = $address ? {
-    ''      => $ipaddress,
-    default => $address,
-  }
   $manage_method = $method ? {
     ''     => $enable_dhcp ? {
       true  => 'dhcp',
       false => 'static',
     },
     default => $method,
+  }
+
+  # Debian specific
+  case $manage_method {
+    'dhcp': { $manage_address = undef }
+    'none': { $manage_address = undef }
+    default: {
+        $manage_address = $address ? {
+          ''      => $ipaddress,
+          default => $address,
+        }
+      }
   }
 
   # Redhat and Suse specific
@@ -266,6 +273,7 @@ define network::interface (
 
       if ! defined(Network::Interface['lo']) {
         network::interface { 'lo':
+          address      => '127.0.0.1',
           method       => 'loopback',
           manage_order => '05',
         }


### PR DESCRIPTION
This should fix the problem with empty address statements on debian systems. The same thing (empty IPADDR options) is likely to occur on Redhat/SuSE systems as well. I do not have a any RedHat or SuSE boxes available right now, so I don't know whether it is in fact a problem or merely a cosmetic issue on these systems.
