### PR TITLE
added debian specific method 'auto'

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -215,6 +215,7 @@ define network::interface (
   # Debian specific
   case $manage_method {
     'dhcp': { $manage_address = undef }
+    'auto': { $manage_address = undef }
     'none': { $manage_address = undef }
     default: {
         $manage_address = $address ? {


### PR DESCRIPTION
Hey...

Great module, but I need support for the method 'auto', so I can create an interface like "iface eth1 inet6 auto" without having to specify an address. It would be great if you included this line into your code.

The code should be OK, but I'm not sure if this is the right way to contribute to your project. I just subscribed to Github about 30 Minutes ago, this is my first pull request ever. ;-)

Bye,
Ronald.
