### PR TITLE
Include main class in interface type

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -192,6 +192,8 @@ define network::interface (
 
   ) {
 
+  include ::network
+
   validate_bool($auto)
   validate_bool($enable)
 


### PR DESCRIPTION
Without the include this type does not have access to the exec that handles the network restart.

ex: 

``` sh
[root@dev modules]# puppet apply --modulepath=./ -e 'network::interface { "eth0:1":
  ipaddress => "192.168.6.252",
  arpcheck => "no"
}'
Warning: Scope(Network::Interface[eth0:1]): Could not look up qualified variable 'network::manage_config_file_notify'; class network has not been evaluated
Notice: Compiled catalog for dev.ebay.local in environment production in 0.35 seconds
Notice: /Stage[main]/Main/Network::Interface[eth0:1]/File[/etc/sysconfig/network-scripts/ifcfg-eth0:1]/ensure: created
Notice: Finished catalog run in 0.02 seconds
```
