### PR TITLE
Manage interface setting arpcheck for RHEL

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -75,6 +75,10 @@
 #    configure dhcp on the interface via the bootproto setting.
 #    If both are present bootproto is used.
 #
+#  $arpcheck      = undef
+#    Whether the interface will check if the supplied IP address is already in
+#    use. Valid values are undef, "yes", "no".
+#
 # Check the arguments in the code for the other RedHat specific settings
 # If defined they are set in the used template.
 #
@@ -185,6 +189,7 @@ define network::interface (
   $bonding_opts    = undef,
   $vlan            = undef,
   $bridge          = undef,
+  $arpcheck        = undef,
 
   # Suse specific
   $startmode       = '',
@@ -199,6 +204,10 @@ define network::interface (
   validate_array($pre_up)
   validate_array($down)
   validate_array($pre_down)
+
+  if $arpcheck != undef and ! ($arpcheck in ["yes", "no"]) {
+    fail("arpcheck must be one of: undef, yes, no")
+  }
 
   $manage_hwaddr = $hwaddr ? {
     default => $hwaddr,

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -59,3 +59,6 @@ VLAN="<%= @vlan %>"
 <% if @bridge -%>
 BRIDGE="<%= @bridge %>"
 <% end -%>
+<% if @arpcheck -%>
+ARPCHECK="<%= @arpcheck %>"
+<% end -%>


### PR DESCRIPTION
Since sometime in RHEL 6.x, the network scripts will check to verify no other host on the network is assigned the same IP address. While this is generally a good thing it can drastically increase startup time. There are also other circumstances when it can be advantageous to disable this check.
