### PR TITLE
Add ZONE for RedHat 7 machines.

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -193,6 +193,7 @@ define network::interface (
   $physdev         = undef,
   $bridge          = undef,
   $arpcheck        = undef,
+  $zone            = undef,
 
   # Suse specific
   $startmode       = '',

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -71,3 +71,6 @@ BRIDGE="<%= @bridge %>"
 <% if @arpcheck -%>
 ARPCHECK="<%= @arpcheck %>"
 <% end -%>
+<% if @zone -%>
+ZONE="<%= @zone %>"
+<% end -%>


### PR DESCRIPTION
This is a feature to workaround the fact that Firewalld does not honor
the interfaces statement in /etc/firewalld/zones/[zone].xml