### PR TITLE
Extend support for osfamily Suse, most notably:

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You have different possibile approaches in the usage of this module. Use the one
 
   On 'Redhat' osfamily: '/etc/sysconfig/network-scripts/ifcfg.eth0' # Yes, quite opinionated, you can change it with config_file_path.
 
-  On 'Suse' osfamily: '/etc/sysconfig/network/ifcfg.eth0'
+  On 'Suse' osfamily: '/etc/sysconfig/network/ifcfg-eth0'
 
         class { 'network':
           config_file_template => 'site/network/network.conf.erb',
@@ -132,7 +132,7 @@ You have different possibile approaches in the usage of this module. Use the one
         }
 
 
-* The network::interface exposes, and uses in the default templates, network configuration parameters available on Debian (most), RedHat (some), Suse (some) so it's flexible, easily expandable and should adapt to any need, but you may still want to provide a custom template with:
+* The network::interface exposes, and uses in the default templates, network configuration parameters available on Debian (most), RedHat (some), Suse (most) so it's flexible, easily expandable and should adapt to any need, but you may still want to provide a custom template with:
 
         network::interface { 'eth0':
           enable_dhcp => true,
@@ -161,13 +161,29 @@ You have different possibile approaches in the usage of this module. Use the one
           gateway   => [ '192.168.1.1', '10.0.0.1', ],
         }
 
+* To configure network routes on Suse, use the routes_hash parameter, like in the following example:
+
+	class { 'network':
+	  routes_hash => {
+            'default' => {
+	      destination => 'default',
+              gateway     => '192.168.0.1',
+              netmask     => '255.255.255.0',
+              interface   => 'eth0',
+              type        => 'unicast',
+            }
+          }
+	}
+
+The parameters netmask, interface and type are optional.
+
 ##Operating Systems Support
 
 This is tested on these OS:
 - RedHat osfamily 5 and 6
 - Debian 6 and 7
 - Ubuntu 10.04, 12.04 and 14.04
-- OpenSuse 12
+- OpenSuse 12, SLES 11SP3
 
 
 ##Development

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -82,6 +82,11 @@
 # Check the arguments in the code for the other RedHat specific settings
 # If defined they are set in the used template.
 #
+# == Suse only parameters
+#
+# Check the arguments in the code for the other Suse specific settings
+# If defined they are set in the used template.
+#
 define network::interface (
 
   $enable          = true,
@@ -194,9 +199,28 @@ define network::interface (
   $bridge          = undef,
   $arpcheck        = undef,
 
-  # Suse specific
+  ## Suse specific
   $startmode       = '',
-  $usercontrol     = 'no'
+  $usercontrol     = 'no',
+  $ethtool_opts    = undef,
+  $firewall        = undef,
+  $aliases         = undef,
+  $remote_ipaddr   = undef,
+
+  # For bonding
+  $bond_master     = undef,
+  $bond_moduleopts = undef,
+  $bond_slaves     = undef,
+
+  # For bridging
+  $bridge          = undef,
+  $bridge_fwddelay = undef,
+  $bridge_ports    = undef,
+  $bridge_stp      = undef,
+
+  # For vlaN
+  $vlan            = undef,
+  $etherdevice     = undef,
 
   ) {
 
@@ -210,8 +234,8 @@ define network::interface (
   validate_array($down)
   validate_array($pre_down)
 
-  if $arpcheck != undef and ! ($arpcheck in ["yes", "no"]) {
-    fail("arpcheck must be one of: undef, yes, no")
+  if $arpcheck != undef and ! ($arpcheck in ['yes', 'no']) {
+    fail('arpcheck must be one of: undef, yes, no')
   }
 
   $manage_hwaddr = $hwaddr ? {
@@ -319,6 +343,25 @@ define network::interface (
     }
 
     'Suse': {
+      if $vlan {
+        if !defined(Package['vlan']) {
+          package { 'vlan':
+            ensure => 'present',
+          }
+        }
+        Package['vlan'] ->
+        File["/etc/sysconfig/network/ifcfg-${name}"]
+      }
+      if $bridge {
+        if !defined(Package['bridge-utils']) {
+          package { 'bridge-utils':
+            ensure => 'present',
+          }
+        }
+        Package['bridge-utils'] ->
+        File["/etc/sysconfig/network/ifcfg-${name}"]
+      }
+
       file { "/etc/sysconfig/network/ifcfg-${name}":
         ensure  => $ensure,
         content => template($template),

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -97,7 +97,6 @@ define network::route (
         content => template('network/route_down-Debian.erb'),
         notify  => $network::manage_config_file_notify,
       }
-
     }
     default: { fail('Operating system not supported')  }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,8 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11 PS1"
+        "11 SP1",
+        "11 SP3"
       ]
     },
     {

--- a/templates/interface/Suse.erb
+++ b/templates/interface/Suse.erb
@@ -2,11 +2,20 @@
 BOOTPROTO="<%= @manage_bootproto %>"
 STARTMODE="<%= @manage_startmode %>"
 USERCONTROL="<%= @usercontrol %>"
+<% if @etherdevice -%>
+ETHERDEVICE="<%= @etherdevice %>"
+<% end -%>
+<% if @ethtool_opts -%>
+ETHTOOL_OPTIONS="<%= @ethtool_opts %>"
+<% end -%>
 <% if @manage_ipaddr -%>
 IPADDR="<%= @manage_ipaddr %>"
 <% end -%>
 <% if @netmask -%>
 NETMASK="<%= @netmask %>"
+<% end -%>
+<% if @network -%>
+NETWORK="<%= @network %>"
 <% end -%>
 <% if @broadcast -%>
 BROADCAST="<%= @broadcast %>"
@@ -16,4 +25,49 @@ GATEWAY="<%= @gateway %>"
 <% end -%>
 <% if @mtu -%>
 MTU="<%= @mtu %>"
+<% end -%>
+<% if @vlan -%>
+VLAN_ID="<%= @vlan %>"
+<% end -%>
+<% if @bridge -%>
+BRIDGE="<%= @bridge %>"
+<% end -%>
+<% if @bridge_fwddelay -%>
+BRIDGE_FORWARDDELAY="<%= @bridge_fwddelay %>"
+<% end -%>
+<% if @bridge_ports -%>
+BRIDGE_PORTS="<%= @bridge_ports %>"
+<% end -%>
+<% if @bridge_stp -%>
+BRIDGE_STP="<%= @bridge_stp %>"
+<% end -%>
+<% if @bond_master -%>
+BONDING_MASTER="<%= @bond_master %>"
+<% end -%>
+<% if @bond_moduleopts -%>
+BONDING_MODULE_OPTS="<%= @bond_moduleopts %>"
+<% end -%>
+<% if @bond_slaves -%>
+  <%- if @bond_slaves.is_a? Array -%>
+    <%- @bond_slaves.each_with_index do |slave,idx| -%>
+BONDING_SLAVE<%= idx %>="<%= slave %>"
+    <%- end -%>
+  <%- else -%>
+BONDING_SLAVE0="<%= @bond_slaves %>"
+  <%- end -%>
+<% end -%>
+<% if @aliases -%>
+  <%- if @aliases.is_a? Array -%>
+    <%- @aliases.each_with_index do |val,idx| -%>
+IPADDR_<%= idx %>="<%= val %>"
+    <%- end -%>
+  <%- else -%>
+IPADDR_0="<%= @aliases %>"
+  <%- end -%>
+<% end -%>
+<% if @firewall -%>
+FIREWALL="<%= @firewall %>"
+<% end -%>
+<% if @remote_ipaddr -%>
+REMOTE_IPADDR="<%= @remote_ipaddr %>"
 <% end -%>

--- a/templates/route-Suse.erb
+++ b/templates/route-Suse.erb
@@ -1,0 +1,3 @@
+<%- @real_routes_hash.each do |route, values| -%>
+<%= values['destination'] %> <%= values['gateway'] %> <% if values['netmask'] %><%= values['netmask'] %><%- else -%>-<%- end -%> <% if values['interface'] %><%= values['interface'] %><%- else -%>-<%- end -%> <% if values['type'] %><%= values['type'] %><%- end %>
+<% end -%>


### PR DESCRIPTION
 - add configuration of vlans
 - add configuration of bridges
 - add configuration of bonding devices
 - add configuration of routes
 - add configuration of hostname

When configuring vlans for bridges, the module
makes sure that the required extra rpm packages
are installed before.

Further updated some of the documentation.
For the routing, I reused the network::route_hash parameter,
but with different values, i.e. example given in README.md.

Developed and tested on SLES11 SP3.