### PR TITLE
Add peerntp param for Redhat servers

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -200,6 +200,8 @@ define network::interface (
 
   ) {
 
+  include ::network
+
   validate_bool($auto)
   validate_bool($enable)
 

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -180,6 +180,7 @@ define network::interface (
   $dhcp_hostname   = undef,
   $srcaddr         = undef,
   $peerdns         = '',
+  $peerntp         = '',
   $onboot          = '',
   $defroute        = undef,
   $dns1            = undef,
@@ -253,6 +254,13 @@ define network::interface (
       default => 'no',
     },
     default => $peerdns,
+  }
+  $manage_peerntp = $peerntp ? {
+    ''     => $manage_bootproto ? {
+      'dhcp'  => 'yes',
+      default => 'no',
+    },
+    default => $peerntp,
   }
   $manage_ipaddr = $ipaddr ? {
     ''      => $ipaddress,

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -5,6 +5,7 @@ ONBOOT="<%= @manage_onboot %>"
 TYPE="<%= @type %>"
 USERCTL="<%= @userctl %>"
 PEERDNS="<%= @manage_peerdns %>"
+PEERNTP="<%= @manage_peerntp %>"
 <% if @uuid -%>
 UUID="<%= @uuid %>"
 <% end -%>


### PR DESCRIPTION
This is an important param for Redhat servers to be able to ignore NTP servers when using DHCP.