### PR TITLE
ensure bridge-utils is present on redhat hosts when needed

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -355,7 +355,7 @@ define network::interface (
         group   => 'root',
         notify  => $network::manage_config_file_notify,
       }
-      if $bridge {
+      if ($bridge or $type == "Bridge") {
         if !defined(Package['bridge-utils']) {
           package { 'bridge-utils':
             ensure => 'present',

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -355,6 +355,15 @@ define network::interface (
         group   => 'root',
         notify  => $network::manage_config_file_notify,
       }
+      if $bridge {
+        if !defined(Package['bridge-utils']) {
+          package { 'bridge-utils':
+            ensure => 'present',
+          }
+        }
+        Package['bridge-utils'] ->
+        File["/etc/sysconfig/network/ifcfg-${name}"]
+      }
     }
 
     'Suse': {


### PR DESCRIPTION
Have rhel7 instances w/o bridge-utils by default, seems reasonable to make sure its there when bringing up a bridge. 