### PR TITLE
Allow Redhat machines to control STP on bridges

### DIFF
--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -75,6 +75,9 @@ PHYSDEV="<%= @physdev %>"
 <% if @bridge -%>
 BRIDGE="<%= @bridge %>"
 <% end -%>
+<% if @bridge_stp -%>
+STP="<%= @bridge_stp %>"
+<% end -%>
 <% if @arpcheck -%>
 ARPCHECK="<%= @arpcheck %>"
 <% end -%>


### PR DESCRIPTION
Just filling in the bridge STP entry already present for SuSE and Debian.