### PR TITLE
Move interface delcaration into parameter section

### DIFF
--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -53,6 +53,7 @@
 #
 define network::route (
   $ipaddress,
+  $interface = $name,
   $netmask,
   $gateway,
   $ensure = 'present'
@@ -63,8 +64,6 @@ define network::route (
   validate_array($gateway)
 
   include 'network'
-
-  $interface = $name
 
   case $::osfamily {
     'RedHat': {


### PR DESCRIPTION
so one can name the rule differently then the interface. This is important when multiple routes are added to the same interface.