### PR TITLE
Set route filenames to the name the resource is given instead of the …

### DIFF
--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -67,32 +67,32 @@ define network::route (
 
   case $::osfamily {
     'RedHat': {
-      file { "route-${interface}":
+      file { "route-${name}":
         ensure  => $ensure,
         mode    => '0644',
         owner   => 'root',
         group   => 'root',
-        path    => "/etc/sysconfig/network-scripts/route-${interface}",
+        path    => "/etc/sysconfig/network-scripts/route-${name}",
         content => template('network/route-RedHat.erb'),
         notify  => $network::manage_config_file_notify,
       }
     }
     'Debian': {
-      file { "routeup-${interface}":
+      file { "routeup-${name}":
         ensure  => $ensure,
         mode    => '0755',
         owner   => 'root',
         group   => 'root',
-        path    => "/etc/network/if-up.d/z90-route-${interface}",
+        path    => "/etc/network/if-up.d/z90-route-${name}",
         content => template('network/route_up-Debian.erb'),
         notify  => $network::manage_config_file_notify,
       }
-      file { "routedown-${interface}":
+      file { "routedown-${name}":
         ensure  => $ensure,
         mode    => '0755',
         owner   => 'root',
         group   => 'root',
-        path    => "/etc/network/if-down.d/z90-route-${interface}",
+        path    => "/etc/network/if-down.d/z90-route-${name}",
         content => template('network/route_down-Debian.erb'),
         notify  => $network::manage_config_file_notify,
       }


### PR DESCRIPTION
…interface to allow multiple routes for one interface. This is an addition to the first change whereby the instance variable was moved into the parameter list of the resource type.

For you to better unterstand the reason behind this change: Puppet was throwing this error:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: File[routeup-outside] is already declared in file .../modules/network/manifests/route.pp:89; cannot redeclare at .../modules/network/manifests/route.pp:89 on node ...
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

This was caused by this manifest:

```
network::route { 'outside-1':
    interface => 'outside',
    ipaddress => [ '...' ],
    netmask   => [ '...' ],
    gateway   => [ "..." ],
  }

  network::route { 'outside-2':
    interface => 'outside',
    ipaddress => [ '...' ],
    netmask   => [ '...' ],
    gateway   => [ "..." ],
  }
```

I just censored some informations with the ... that aren't necessary to know for this problem.

After this patch the module will create a file for every resource with the unique name of the resource.