### PR TITLE
Debian networking configuration enhancements 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,8 @@ class network (
   $config_file_content       = undef,
   $config_file_options_hash  = { } ,
 
+  $config_file_per_interface = false,
+
   $config_dir_path           = $network::params::config_dir_path,
   $config_dir_source         = undef,
   $config_dir_purge          = false,

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -323,6 +323,14 @@ define network::interface (
   case $::osfamily {
 
     'Debian': {
+      if $vlan_raw_device {
+        if !defined(Package['vlan']) {
+          package { 'vlan':
+            ensure => 'present',
+          }
+        }
+      }
+
       if ! defined(Concat['/etc/network/interfaces']) {
         concat { '/etc/network/interfaces':
           mode   => '0644',


### PR DESCRIPTION
**First thing** that we need vlan package on Debian systems when configuring tagged interface, for an example with hiera:
```ruby
---
network::interfaces_hash:
  eth0.101:
    ipaddress: "10.0.4.250"
    netmask: "255.0.0.0"
    vlan_raw_device: eth0
  eth1.102:
    ipaddress: "172.16.16.22"
    netmask: "255.255.255.192"
    vlan_raw_device: eth1
```
The **next thing** is more related to security, it allows to create a separate config file per interface (in /etc/network/interfaces.d/). It will not overwrite main file /etc/network/interfaces and you will not loose network connectivity after ifup/ifdown. To enable it:
```ruby
class { "network":
  config_file_per_interface => true
}
```
or using hiera:
```ruby
---
network::config_file_per_interface: true
```
In this case we will also ensure, that we have following line in **/etc/network/interfaces**:
```
source /etc/network/interfaces.d/*.cfg
```

Thanks!