### PR TITLE
Added NOZEROCONF option to interface initialization

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -83,6 +83,10 @@
 #    Used to enable or disable ARP completely for an interface at initialization
 #    Valid values are undef, "yes", "no".
 #
+#  $nozeroconf    = undef
+#    Used to enable or disable ZEROCONF routes completely for an interface at initialization
+#    Valid values are undef, "yes, 'no".
+#
 # Check the arguments in the code for the other RedHat specific settings
 # If defined they are set in the used template.
 #

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -209,6 +209,7 @@ define network::interface (
   $arpcheck        = undef,
   $zone            = undef,
   $arp             = undef,
+  $nozeroconf      = undef,
 
   ## Suse specific
   $startmode       = '',
@@ -250,6 +251,10 @@ define network::interface (
 
   if $arpcheck != undef and ! ($arpcheck in ['yes', 'no']) {
     fail('arpcheck must be one of: undef, yes, no')
+  }
+
+  if $nozeroconf != undef and ! ($nozeroconf in ['yes', 'no']) {
+    fail('nozeroconf must be one of: undef, yes, no')
   }
 
   $manage_hwaddr = $hwaddr ? {


### PR DESCRIPTION
RHEL specific NOZEROCONF 'yes/no' option, to enable or disable the ZEROCONF routes.

This is a bit ambigous in RHEL, since 'yes' means DISABLING this option, and 'no' means ENABLING it.