### PR TITLE
Improve sysconfig/network logic on RHEL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -224,9 +224,12 @@ class network (
   }
 
 
-  # Configure default gateway (On RedHat). Also hostname is set.
+  # Configure sysconfig/network (On RedHat).
   if $::osfamily == 'RedHat'
-  and $network::gateway {
+    and ($network::gateway
+    or $network::hostname
+    or $network::ipv6enable
+    or $network::nozeroconf) {
     file { '/etc/sysconfig/network':
       ensure  => $config_file_ensure,
       mode    => $config_file_mode,

--- a/templates/hostname-RedHat.erb
+++ b/templates/hostname-RedHat.erb
@@ -10,4 +10,6 @@ NOZEROCONF="<%= @nozeroconf %>"
 NETWORKING_IPV6="<%= @ipv6enable %>"
 IPV6INIT="<%= @ipv6enable %>"
 <% end -%>
-HOSTNAME="<%= @manage_hostname.split('.').first %>"
+<% if @hostname -%>
+HOSTNAME="<%= @hostname %>"
+<% end -%>


### PR DESCRIPTION
- This changes the logic around managing /etc/sysconfig/network
  on RHEL. The file will be managed only if one of its related params
  are set. Using the gateway param as a trigger is no longer required.
- It is most common to use FQDN as the HOSTNAME value. Fixes #35
- This change is not 100% backwards compatible. Up until this commit,
  if you set gateway you'd get a default value for HOSTNAME too. After
  this commit, the default no longer applies and will be removed.
