### PR TITLE
Fix ifup/ifdown issues on Ubuntu and possibly Debian systems

### DIFF
--- a/templates/mroute_down-Debian.erb
+++ b/templates/mroute_down-Debian.erb
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 ###
 ### File managed by Puppet
 ###

--- a/templates/mroute_up-Debian.erb
+++ b/templates/mroute_up-Debian.erb
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 ###
 ### File managed by Puppet
 ###


### PR DESCRIPTION
At least with upstart networking, Ubuntu 14.04 complains that these files do not have a shebang and cannot execute. This resolves the issue.