### PR TITLE
add support for routing scope and source keywords

### DIFF
--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -10,7 +10,10 @@
 #
 #   $ipaddress - required
 #   $netmask   - required
-#   $gateway   - required
+#   $gateway   - optional
+#   $scope     - optional
+#   $source    - optional
+#   $table     - optional
 #
 # [*config_file_notify*]
 #   String. Optional. Default: 'class_default'
@@ -42,7 +45,7 @@
 #     gateway   => [ '192.168.1.1', '10.0.0.1', ],
 #   }
 #
-# A specifc routing table can also be specified for the route:
+# A routing table can also be specified for the route:
 #
 #   network::route { 'eth1':
 #     ipaddress => [ '192.168.3.0', ],
@@ -51,16 +54,37 @@
 #     table     => [ 'vlan22' ],
 #   }
 #
-# If adding routes to specific routing tables on an interface with multiple
-# routes, it is required to explicitly add the 'main' table to all other routes.
+# If adding routes to a routing table on an interface with multiple routes, it
+# is necessary to specify false or 'main' for the table on the other routes.
 # The 'main' routing table is where routes are added by default.
 #
+# The same applies if adding scope, source or gateway, i.e. false needs to be
+# specified for those routes without values for those parameters, if defining
+# multiple routes for the same interface.
+#
+# The first two routes in the following example are functionally equivalent to
+# the routes added in the example above for bond2.
+#
 #   network::route { 'bond2':
-#     ipaddress => [ '192.168.2.0', '10.0.0.0', '192.168.3.0', ]
-#     netmask   => [ '255.255.255.0', '255.0.0.0', '255.255.255.0', ],
-#     gateway   => [ '192.168.1.1', '10.0.0.1', '192.168.3.1', ],
-#     table     => [ 'main', 'main', 'vlan22' ],
+#     ipaddress => [ '192.168.2.0', '10.0.0.0', '0.0.0.0', '192.168.3.0' ]
+#     netmask   => [ '255.255.255.0', '255.0.0.0', '0.0.0.0', '255.255.255.0' ],
+#     gateway   => [ '192.168.1.1', '10.0.0.1', '192.168.3.1', false ],
+#     scope     => [ false, false, false, 'link', ],
+#     source    => [ false, false, false, '192.168.3.10', ],
+#     table     => [ false, false, 'vlan22' 'vlan22', ],
 #   }
+#
+# The second two routes yield the following routes in table vlan22:
+#
+# # ip route show table vlan22
+# default via 192.168.3.1 dev bond2
+# 192.168.3.0/255.255.255.0 dev bond2 scope link src 192.168.3.10
+#
+# Normally the link level routing (192.168.3.0/255.255.255.0) is added
+# automatically by the kernel when an interface is brought up. When using routing
+# rules and routing tables, this does not happen, so this route must be added
+# manually.
+#
 #
 # === Authors:
 #
@@ -74,7 +98,9 @@
 define network::route (
   $ipaddress,
   $netmask,
-  $gateway,
+  $gateway   = undef,
+  $scope     = undef,
+  $source    = undef,
   $table     = undef,
   $interface = $name,
   $ensure    = 'present'
@@ -82,7 +108,18 @@ define network::route (
   # Validate our arrays
   validate_array($ipaddress)
   validate_array($netmask)
-  validate_array($gateway)
+
+  if $gateway {
+    validate_array($gateway)
+  }
+
+  if $scope {
+    validate_array($scope)
+  }
+
+  if $source {
+    validate_array($source)
+  }
 
   if $table {
     validate_array($table)

--- a/templates/route-RedHat.erb
+++ b/templates/route-RedHat.erb
@@ -2,5 +2,5 @@
 ### File managed by Puppet
 ###
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-<%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %><%- if @table -%> table <%= @table[id] %><% end %>
+<%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %>
 <%- end %>

--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -4,6 +4,6 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route del <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %> <%- if @table -%> table <%= @table[id] %><% end %>
+    ip route del <%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %> <%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %>
 <%- end -%>
 fi

--- a/templates/route_up-Debian.erb
+++ b/templates/route_up-Debian.erb
@@ -4,6 +4,6 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route add <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %> <%- if @table -%> table <%= @table[id] %><% end %>
+    ip route add <%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %> <%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %>
 <%- end -%>
 fi


### PR DESCRIPTION
This commit adds support for two iproute2 keywords; "scope" and "source". This allows us to specify the source IP address and/or the scope of a route. This is especially useful when using source policy routing with routing tables. One specific use is to add the link-level routing rules that are normally added by the kernel, but do not get added when a route is added to a routing table manually.