### PR TITLE
Fix ERB syntax in Debian route templates

### DIFF
--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -4,6 +4,6 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route del <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %><%- if @table -%>table <%= @table[id] %><%- end -%>
+    ip route del <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %><%- if @table -%>table <%= @table[id] %><% end %>
 <%- end -%>
 fi

--- a/templates/route_up-Debian.erb
+++ b/templates/route_up-Debian.erb
@@ -4,6 +4,6 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route add <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %><%- if @table -%>table <%= @table[id] %><%- end -%>
+    ip route add <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %><%- if @table -%>table <%= @table[id] %><% end %>
 <%- end -%>
 fi


### PR DESCRIPTION
Related to pull request #99; this pull request fixes the same erb syntax error for the Debian route templates

The error prevents a new line from being created between each of the `ip route` commands, causing the resulting script to fail.