### PR TITLE
Fixed missing space in Debian table conditional

### DIFF
--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -4,6 +4,6 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route del <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %><%- if @table -%>table <%= @table[id] %><% end %>
+    ip route del <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %> <%- if @table -%> table <%= @table[id] %><% end %>
 <%- end -%>
 fi

--- a/templates/route_up-Debian.erb
+++ b/templates/route_up-Debian.erb
@@ -4,6 +4,6 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route add <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %><%- if @table -%>table <%= @table[id] %><% end %>
+    ip route add <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %> <%- if @table -%> table <%= @table[id] %><% end %>
 <%- end -%>
 fi


### PR DESCRIPTION
The missing space was making a route with a specific lookup table fail because "dev eth0table mytable"  were getting jammed together.