### PR TITLE
Fix for #112: Add support for bond option num_grat_arp on Debian derived systems

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -228,6 +228,7 @@ define network::interface (
   $bond_primary    = undef,
   $bond_slaves     = [ ],
   $bond_xmit_hash_policy    = undef,
+  $bond_num_grat_arp = undef,
 
   # For bridging
   $bridge_ports    = [ ],

--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -141,6 +141,9 @@ allow-hotplug <%= @interface %>
 <% if @bond_lacp_rate -%>
     bond-lacp-rate <%= @bond_lacp_rate %>
 <% end -%>
+<% if @bond_num_grat_arp -%>
+    bond-num_grat_arp <%= @bond_num_grat_arp %>
+<% end -%>
 <% if @bond_downdelay -%>
     bond-downdelay <%= @bond_downdelay %>
 <% end -%>


### PR DESCRIPTION
1. I'm not sure if this is a bug fix or an enhancement.
1. I didn't add any new puppet-lint errors.
