### PR TITLE
Additional bonding options for Debian

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -232,6 +232,10 @@ define network::interface (
   $bond_slaves     = [ ],
   $bond_xmit_hash_policy    = undef,
   $bond_num_grat_arp = undef,
+  $bond_arp_all = undef,
+  $bond_arp_interval = undef,
+  $bond_arp_iptarget = undef,
+  $bond_fail_over_mac = undef,
   $use_carrier     = undef,
   $primary_reselect = undef,
 

--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -160,7 +160,7 @@ allow-hotplug <%= @interface %>
     arp_ip_target <%= @bond_arp_iptarget.join(',') %>
 <% end -%>
 <% if @bond_fail_over_mac -%>
-     fail_over_mac <%= @bond_fail_over_mac %>
+    fail_over_mac <%= @bond_fail_over_mac %>
 <% end -%>
 <% if @bond_master -%>
     bond-master <%= @bond_master %>

--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -150,6 +150,18 @@ allow-hotplug <%= @interface %>
 <% if @bond_updelay -%>
     bond-updelay <%= @bond_updelay %>
 <% end -%>
+<% if @bond_arp_all -%>
+    arp_all_targets <%= @bond_arp_all %>
+<% end -%>
+<% if @bond_arp_interval -%>
+    arp_interval <%= @bond_arp_interval %>
+<% end -%>
+<% if @bond_arp_iptarget -%>
+    arp_ip_target <%= @bond_arp_iptarget.join(',') %>
+<% end -%>
+<% if @bond_fail_over_mac -%>
+     fail_over_mac <%= @bond_fail_over_mac %>
+<% end -%>
 <% if @bond_master -%>
     bond-master <%= @bond_master %>
 <% end -%>


### PR DESCRIPTION
- This allows debian systems to run with four additional bonding options within e/n/i, Specifically around arp options detailed within https://www.kernel.org/doc/Documentation/networking/bonding.txt
- This is tested against (and working) against ubuntu trusty and xenial.
- This functionality already exists for redhat systems within the much-more-flexible $bonding_opts


