### PR TITLE
Add support for Teaming, fixes #131

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -235,6 +235,10 @@ define network::interface (
   $use_carrier     = undef,
   $primary_reselect = undef,
 
+  # For teaming
+  $team_config = undef,
+  $team_master = undef,
+
   # For bridging
   $bridge_ports    = [ ],
   $bridge_stp      = undef,

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -76,6 +76,12 @@ BONDING_OPTS="<%= @bonding_opts %>"
 BONDING_OPTS="<%- if @bond_mode -%>mode=<%= @bond_mode %><%- end -%><%- if @bond_miimon -%> miimon=<%= @bond_miimon %><%- end -%>"
 <% end -%>
 <% end -%>
+<% if @team_config -%>
+TEAM_CONFIG='<%= @team_config -%>'
+<% end -%>
+<% if @team_master -%>
+TEAM_MASTER=<%= @team_master %>
+<% end -%>
 <% if @mtu -%>
 MTU="<%= @mtu %>"
 <% end -%>


### PR DESCRIPTION
Minor code change to support teaming on RHEL 7 (and derivatives).

It's done in the same way as bonding has been done.