### PR TITLE
change redhat and suse interface templates to avoid blank ipaddr entry

### DIFF
--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -21,7 +21,7 @@ LAYER2="<%= @layer2 %>"
 <% if @nettype -%>
 NETTYPE="<%= @nettype %>"
 <% end -%>
-<% if @manage_ipaddr -%>
+<% if @manage_ipaddr and ! @manage_ipaddr.empty? -%>
 IPADDR="<%= @manage_ipaddr %>"
 <% end -%>
 <% if @netmask -%>

--- a/templates/interface/Suse.erb
+++ b/templates/interface/Suse.erb
@@ -8,7 +8,7 @@ ETHERDEVICE="<%= @etherdevice %>"
 <% if @ethtool_opts -%>
 ETHTOOL_OPTIONS="<%= @ethtool_opts %>"
 <% end -%>
-<% if @manage_ipaddr -%>
+<% if @manage_ipaddr and ! @manage_ipaddr.empty? -%>
 IPADDR="<%= @manage_ipaddr %>"
 <% end -%>
 <% if @netmask -%>


### PR DESCRIPTION
Since the ipaddress/ipaddr parameter defaults to an empty string, if you are using DHCP for an interface you end up with an entry like:

IPADDR=""

That doesn't really hurt anything as it seems to be ignored, but I added the empty string check to the RedHat and Suse templates so they do the same thing that the Debian templates do. 