### PR TITLE
Add support for cumulus linux interfaces

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -451,16 +451,32 @@ define network::interface (
       }
 
       if $network::config_file_per_interface {
-        file { "interface-${name}":
-          path    => "/etc/network/interfaces.d/${name}.cfg",
-          content => template($template),
-          notify  => $network::manage_config_file_notify
-        }
-        if ! defined(File_line['config_file_per_interface']) {
-          file_line { 'config_file_per_interface':
-            path   => '/etc/network/interfaces',
-            line   => 'source /etc/network/interfaces.d/*.cfg',
-            notify => $network::manage_config_file_notify,
+        if $::operatingsystem == 'CumulusLinux' {
+          file { "interface-${name}":
+            path    => "/etc/network/interfaces.d/${name}",
+            content => template($template),
+            notify  => $network::manage_config_file_notify
+          }
+          if ! defined(File_line['config_file_per_interface']) {
+            file_line { 'config_file_per_interface':
+              path   => '/etc/network/ifupdown2/ifupdown2.conf',
+              line   => 'addon_scripts_support=1',
+              match  => 'addon_scripts_suppor*',
+              notify => $network::manage_config_file_notify,
+            }
+          }
+        } else {
+          file { "interface-${name}":
+            path    => "/etc/network/interfaces.d/${name}.cfg",
+            content => template($template),
+            notify  => $network::manage_config_file_notify
+          }
+          if ! defined(File_line['config_file_per_interface']) {
+            file_line { 'config_file_per_interface':
+              path   => '/etc/network/interfaces',
+              line   => 'source /etc/network/interfaces.d/*.cfg',
+              notify => $network::manage_config_file_notify,
+            }
           }
         }
       } else {


### PR DESCRIPTION
PR regarding issue #128 

This change adds support for configuring interfaces in Cumulus Linux with add-on scripts for ifupdown2.

Default behaviour is not changed.

Tested on Cumulus Linux 2.5.x