### PR TITLE
Issue #141 Netmask is wrong

### DIFF
--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -31,7 +31,13 @@ IPADDR="<%= @manage_ipaddr %>"
 <% end -%>
 <% end -%>
 <% if @netmask -%>
+<% if @ipaddress.kind_of?(Array) -%>
+<%- (1..(@ipaddress.length)).each do |id| -%>
+NETMASK<%= id %>="<%= @netmask %>"
+<% end -%>
+<% else -%>
 NETMASK="<%= @netmask %>"
+<% end -%>
 <% end -%>
 <% if @broadcast -%>
 BROADCAST="<%= @broadcast %>"


### PR DESCRIPTION
The network is set to /16 when using this version. There are two ways for integration. Way 1 (this version) use same netmask on every interface. Way 2 set an array for the network interface for every ip address.

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

