### PR TITLE
Suse default route example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,21 +162,18 @@ You have different possibile approaches in the usage of this module. Use the one
           gateway   => [ '192.168.1.1', '10.0.0.1', ],
         }
 
-* To configure network routes on Suse, use the routes_hash parameter, like in the following example:
+* To configure the default route on Suse, use the routes_hash parameter, like in the following example:
 
         class { 'network':
           routes_hash => {
-            'default' => {
-              destination => 'default',
-              gateway     => '192.168.0.1',
-              netmask     => '255.255.255.0',
+            'eth0' => {
+              ipaddress   => [ 'default', ],
+              gateway     => [ '192.168.0.1', ],
+              netmask     => [ '-', ],
               interface   => 'eth0',
-              type        => 'unicast',
             }
           }
         }
-
-The parameters netmask, interface and type are optional.
 
 * An alternative way to manage routes is using the network::mroute define, which expectes an hash of one of more routes where you specify the network and the gateway (either as ip or device name):
 


### PR DESCRIPTION
The example Suse default route does not work and fails to compile the catalog and produces errors on the puppet server:

> 2017-01-18 15:43:53,471 ERROR [qtp1483548753-68] [puppetserver] Puppet Evaluation Error: Error while evaluating a Resource Statement, Network::Route[default]:
>   has no parameter named 'destination'
>   expects a value for parameter 'ipaddress'
>   expects a value for parameter 'netmask' on node XX.YY.ZZ
> 

Manged to work out the incantation for Suse 12.1
```
network::routes_hash:
  'bond0':
    ipaddress:
      - 'default'
    netmask:
      - '-'
    gateway:
      - '10.129.1.254'
    interface: 'bond0'
```

I hope I have the PR correct. Please let me know if you require more information
