### PR TITLE
add wpa options for debian (#105)

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -280,6 +280,20 @@ define network::interface (
   $bridge_maxwait        = undef,
   $bridge_waitport       = undef,
 
+  # For wpa_supplicant
+  $wpa_ssid              = undef,
+  $wpa_bssid             = undef,
+  $wpa_psk               = undef,
+  $wpa_key_mgmt          = [ ],
+  $wpa_group             = [ ],
+  $wpa_pairwise          = [ ],
+  $wpa_auth_alg          = [ ],
+  $wpa_proto             = [ ],
+  $wpa_identity          = undef,
+  $wpa_password          = undef,
+  $wpa_scan_ssid         = undef,
+  $wpa_ap_scan           = undef,
+
   ## RedHat specific
   $ipaddr                = '',
   $uuid                  = undef,
@@ -373,6 +387,11 @@ define network::interface (
   validate_array($slaves)
   validate_array($bond_slaves)
   validate_array($bridge_ports)
+  validate_array($wpa_key_mgmt)
+  validate_array($wpa_group)
+  validate_array($wpa_pairwise)
+  validate_array($wpa_auth_alg)
+  validate_array($wpa_proto)
 
   # $subchannels is only valid for zLinux/SystemZ/s390x.
   if $::architecture == 's390x' {

--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -195,4 +195,40 @@ allow-hotplug <%= @interface %>
 <% if @primary_reselect -%>
     primary_reselect <%= @primary_reselect %>
 <% end -%>
+<% if @wpa_ssid -%>
+    wpa-ssid <%= @wpa_ssid %>
+<% end -%>
+<% if @wpa_bssid -%>
+    wpa-bssid <%= @wpa_bssid %>
+<% end -%>
+<% if @wpa_psk -%>
+    wpa-psk <%= @wpa_psk %>
+<% end -%>
+<% if @wpa_key_mgmt.size > 0 then -%>
+    wpa-key-mgmt <%= @wpa_key_mgmt.join(' ') %>
+<% end -%>
+<% if @wpa_group.size > 0 then -%>
+    wpa-group <%= @wpa_group.join(' ') %>
+<% end -%>
+<% if @wpa_pairwise.size > 0 then -%>
+    wpa-pairwise <%= @wpa_pairwise.join(' ') %>
+<% end -%>
+<% if @wpa_auth_alg.size > 0 then -%>
+    wpa-auth-alg <%= @wpa_auth_alg.join(' ') %>
+<% end -%>
+<% if @wpa_proto.size > 0 then -%>
+    wpa-proto <%= @wpa_proto.join(' ') %>
+<% end -%>
+<% if @wpa_identity -%>
+    wpa-identity <%= @wpa_identity %>
+<% end -%>
+<% if @wpa_password -%>
+    wpa-password <%= @wpa_password %>
+<% end -%>
+<% if @wpa_scan_ssid -%>
+    wpa-scan-ssid <%= @wpa_scan_ssid %>
+<% end -%>
+<% if @wpa_ap_scan -%>
+    wpa-ap-scan <%= @wpa_ap_scan %>
+<% end -%>
 


### PR DESCRIPTION
This adds the wpa parameters to the interface define for debian. I implemented all the parameters described in /usr/share/doc/wpasupplicant/README.modes.gz. As the documents mentioned there may be more but it is unsure if they are even implemented on the network config side.