### PR TITLE
Fix IPV6 Format, ISSUE#159

### DIFF
--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -78,7 +78,7 @@ IPV6INIT="<%= @ipv6init %>"
 IPV6_AUTOCONF="<%= @ipv6_autoconf %>"
 <% end -%>
 <% if @ipv6addr -%>
-IPV6_ADDR="<%= @ipv6addr %>"
+IPV6ADDR="<%= @ipv6addr %>"
 <% end -%>
 <% if @ipv6_defaultgw -%>
 IPV6_DEFAULTGW="<%= @ipv6_defaultgw %>"


### PR DESCRIPTION
Fix Syntax for IPV6ADDR should not have an underscore, causes for RHEL to throw an obscure error about not being able to add a default route. 


