### PR TITLE
Adding VLAN_ID support to allow custom device names

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -321,6 +321,7 @@ define network::interface (
   $bonding_opts          = undef,
   $vlan                  = undef,
   $vlan_name_type        = undef,
+  $vlan_id               = undef,
   $physdev               = undef,
   $bridge                = undef,
   $arpcheck              = undef,

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -129,7 +129,7 @@ MTU="<%= @mtu %>"
 <% if @vlan -%>
 VLAN="<%= @vlan %>"
 <% end -%>
-<% if @vlan -%>
+<% if @vlan_id -%>
 VLAN_ID="<%= @vlan_id %>"
 <% end -%>
 <% if @vlan_name_type -%>

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -129,6 +129,9 @@ MTU="<%= @mtu %>"
 <% if @vlan -%>
 VLAN="<%= @vlan %>"
 <% end -%>
+<% if @vlan -%>
+VLAN_ID="<%= @vlan_id %>"
+<% end -%>
 <% if @vlan_name_type -%>
 VLAN_NAME_TYPE="<%= @vlan_name_type %>"
 <% end -%>


### PR DESCRIPTION
This patch makes it possible to specify a VLAN_ID
When doing so you are able to create an interface called WAN for exaple
and then add VLAN's on this interface like

PROVIDER1@WAN
PROVIDER2@WAN

Which makes identifying interfaces a LOT more sane

