### PR TITLE
Add option for team port configuration #165

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -272,7 +272,7 @@ define network::interface (
 
   # For teaming
   $team_config           = undef,
-  $team_port_cfg         = undef,
+  $team_port_config      = undef,
   $team_master           = undef,
 
   # For bridging

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -272,6 +272,7 @@ define network::interface (
 
   # For teaming
   $team_config           = undef,
+  $team_port_cfg         = undef,
   $team_master           = undef,
 
   # For bridging

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -124,7 +124,7 @@ TEAM_CONFIG='<%= @team_config -%>'
 TEAM_MASTER=<%= @team_master %>
 <% end -%>
 <% if @team_port_cfg -%>
-TEAM_PORT_CONFIG='<%= @team_port_cfg %>'
+TEAM_PORT_CONFIG='<%= @team_port_config %>'
 <% end -%>
 <% if @mtu -%>
 MTU="<%= @mtu %>"

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -123,6 +123,9 @@ TEAM_CONFIG='<%= @team_config -%>'
 <% if @team_master -%>
 TEAM_MASTER=<%= @team_master %>
 <% end -%>
+<% if @team_port_cfg -%>
+TEAM_PORT_CONFIG='<%= @team_port_cfg %>'
+<% end -%>
 <% if @mtu -%>
 MTU="<%= @mtu %>"
 <% end -%>


### PR DESCRIPTION
These changes enable the opportunity to configure TEAM_PORT_CONFIG for individual team members on RedHat based systems.

I've called the option $team_port_cfg to avoid it being to long. If you prefer $team_port_config, let me know and I'll change it.