### PR TITLE
add ipv6 to route.pp for debian

### DIFF
--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -104,6 +104,7 @@ define network::route (
   $scope     = undef,
   $source    = undef,
   $table     = undef,
+  $family    = undef,
   $interface = $name,
   $ensure    = 'present'
 ) {
@@ -129,6 +130,10 @@ define network::route (
 
   if $table {
     validate_array($table)
+  }
+
+  if $family {
+    validate_array($family)
   }
 
   include ::network

--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -4,6 +4,6 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route del <%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %> <%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
+    ip<%- if @family and @family[id] == 'inet6' -%> -6<%- end -%> route del <%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %> <%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
 <%- end -%>
 fi

--- a/templates/route_up-Debian.erb
+++ b/templates/route_up-Debian.erb
@@ -4,6 +4,6 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route add <%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %> <%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
+    ip<%- if @family and @family[id] == 'inet6' -%> -6<%- end -%> route add <%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %> <%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
 <%- end -%>
 fi


### PR DESCRIPTION
As per #172 

This PR allows for an extra array within route.pp.  If family is defined as inet6, it passes '-6' into ip command within the route template(s).  This allows for functional ipv6 routes to be set alongside existing ipv4 routes.  This is inline with the $family string in interface.pp.

This PR does not change any existing/default behaviour in the module.

This is working reliably in ubuntu trusty & xenial.

In the future, this behaviour could be extended into redhat/suse (and then documented).