### PR TITLE
Rename gateway if multiple ips are configured Fixes #176

### DIFF
--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -69,7 +69,11 @@ NETMASK="<%= @netmask %>"
 BROADCAST="<%= @broadcast %>"
 <% end -%>
 <% if @gateway -%>
+<% if @ipaddress.kind_of?(Array) -%>
+GATEWAY1="<%= @gateway %>"
+<% else -%>
 GATEWAY="<%= @gateway %>"
+<% end -%>
 <% end -%>
 <% if @manage_defroute -%>
 DEFROUTE="<%= @manage_defroute %>"


### PR DESCRIPTION
This renames `GATEWAY` to `GATEWAY1` if there are multiple addresses configured on Red Hat. Otherwise the default gateway is not properly set.