### PR TITLE
#182: network::interface: Remove ensure parameter from concat::fragment resource

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -645,7 +645,6 @@ define network::interface (
         }
 
         concat::fragment { "interface-${name}":
-          ensure  => $ensure,
           target  => '/etc/network/interfaces',
           content => template($template),
           order   => $manage_order,


### PR DESCRIPTION
Fixes #182

* Hasn't done anything for a while
* Deprecation warning in concat 3
* Removed in concat 4