### PR TITLE
Allow defining default parameters for interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You have different possibile approaches in the usage of this module. Use the one
 
   On 'RedHat' osfamily: it will create the file '/etc/sysconfig/network-scripts/route-eth0'
 
-  You can provide to the main network class the routes_hash parameter to manage all your routes via an hash.
+  You can provide to the main network class the routes_hash parameter to manage all your routes via a hash.
 
 * This example add 2 static routes on the interface bond2
 
@@ -174,7 +174,7 @@ You have different possibile approaches in the usage of this module. Use the one
           }
         }
 
-* An alternative way to manage routes is using the network::mroute define, which expectes an hash of one of more routes where you specify the network and the gateway (either as ip or device name):
+* An alternative way to manage routes is using the network::mroute define, which expectes a hash of one or more routes where you specify the network and the gateway (either as ip or device name):
 
         network::mroute { 'bond2':
           routes => {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,12 @@
 #   - Second level: Interface options (check network::interface for the
 #     available options)
 #   If an hash is provided here, network::interface defines are declared with:
-#   create_resources("network::interface", $interfaces_hash)
+#   create_resources("network::interface", $interfaces_hash, $default_interfaces_hash)
+#
+# [*default_interfaces_hash*]
+#   Hash. Default {}.
+#   Values applied to all interfaces, if they don't specify a more specific value
+#   themselves.
 #
 # [*routes_hash*]
 #   Hash. Default undef.
@@ -56,6 +61,7 @@ class network (
   $hostname                  = undef,
 
   $interfaces_hash           = undef,
+  $default_interfaces_hash   = {},
   $routes_hash               = undef,
   $mroutes_hash              = undef,
   $rules_hash                = undef,
@@ -236,7 +242,7 @@ class network (
   # Create network interfaces from interfaces_hash, if present
 
   if $real_interfaces_hash {
-    create_resources('network::interface', $real_interfaces_hash)
+    create_resources('network::interface', $real_interfaces_hash, $default_interfaces_hash)
   }
 
   if $real_routes_hash {


### PR DESCRIPTION
Allows to specify a `default_interfaces_hash` containing values that get applied to interfaces which do not specify their own value for the specific parameter.
    
```
    network::default_interfaces_hash:
      dns1: 8.8.8.8
      dns2: 8.8.4.4
    
    network::interfaces_hash:
      eth0:
        method: manual
        ipaddress: 10.13.37.23
        netmask: 255.255.0.0
      eth1:
        method: manual
        ipaddress: 10.42.13.37
        netmask: 255.255.255.0
      eth2:
        method: manual
        ipaddress: 192.168.0.5
        netmask: 255.255.255.0
        dns1: 192.168.0.1
        dns2: ""
````

In the above example, both `eth0` and `eth1` will have the parameters
```
    dns1: 8.8.8.8
    dns2: 8.8.4.4
``` 
 applied to them. `eth2` however, will use `192.168.0.1` as the DNS.

