### PR TITLE
Make debian up/down scripts react to --all. Fixes #187

### DIFF
--- a/templates/mroute_down-Debian.erb
+++ b/templates/mroute_down-Debian.erb
@@ -3,7 +3,7 @@
 ###
 ### File managed by Puppet
 ###
-if [ "$IFACE" = "<%= @interface -%>" ]; then
+if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
 <% @routes.each do |net,gw| -%>
   ip route del <%= net %> <% if /^\d/.match(gw) %>via<% else %>dev<% end %> <%= gw %>
 <% end -%>

--- a/templates/mroute_up-Debian.erb
+++ b/templates/mroute_up-Debian.erb
@@ -3,7 +3,7 @@
 ###
 ### File managed by Puppet
 ###
-if [ "$IFACE" = "<%= @interface -%>" ]; then
+if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
 <% @routes.each do |net,gw| -%>
   ip route add <%= net %> <% if /^\d/.match(gw) %>via<% else %>dev<% end %> <%= gw %>
 <% end -%>

--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -2,7 +2,7 @@
 #
 ### File managed by Puppet
 #
-if [ "$IFACE" = "<%= @interface -%>" ]; then
+if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
     ip<%- if @family and @family[id] == 'inet6' -%> -6<%- end -%> route del <%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %> <%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
 <%- end -%>

--- a/templates/route_up-Debian.erb
+++ b/templates/route_up-Debian.erb
@@ -2,7 +2,7 @@
 #
 ### File managed by Puppet
 #
-if [ "$IFACE" = "<%= @interface -%>" ]; then
+if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
     ip<%- if @family and @family[id] == 'inet6' -%> -6<%- end -%> route add <%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %> <%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
 <%- end -%>

--- a/templates/rule_down-Debian.erb
+++ b/templates/rule_down-Debian.erb
@@ -2,7 +2,7 @@
 #
 ### File managed by Puppet
 #
-if [ "$IFACE" = "<%= @interface -%>" ]; then
+if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
 <%- (0..(@iprule.length-1)).each do |id| -%>
     ip rule del <%= @iprule[id] %>
 <%- end -%>

--- a/templates/rule_up-Debian.erb
+++ b/templates/rule_up-Debian.erb
@@ -2,7 +2,7 @@
 #
 ### File managed by Puppet
 #
-if [ "$IFACE" = "<%= @interface -%>" ]; then
+if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
 <%- (0..(@iprule.length-1)).each do |id| -%>
     ip rule add <%= @iprule[id] %>
 <%- end -%>


### PR DESCRIPTION
This commit fixes the issue described in #187. All scripts are executed either if the corresponding interface comes up, or if all interfaces are started.

