### PR TITLE
Fix typo in parameter name

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -401,7 +401,7 @@ define network::interface (
   $ovs_extra             = undef,
   $ovs_options           = undef,
   $ovs_patch_peer        = undef,
-  $ovsrequries           = undef,
+  $ovsrequires           = undef,
   $ovs_tunnel_type       = undef,
   $ovs_tunnel_options    = undef,
   $ovsdhcpinterfaces     = undef,

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -205,8 +205,8 @@ OVSDHCPINTERFACES="<%= @ovsdhcpinterfaces %>"
 <% if @ovsbootproto -%>
 OVSBOOTPROTO="<%= @ovsbootproto %>"
 <% end -%>
-<% if @ovsrequries -%>
-OVSREQURIES="<%= @ovsrequries %>"
+<% if @ovsrequires -%>
+OVSREQUIRES="<%= @ovsrequires %>"
 <% end -%>
 <% if @check_link_down == true -%>
 check_link_down() {


### PR DESCRIPTION
This impacts both the Puppet module parameter (should be ovsrequires)
and the Red Hat sysconfig parameter (should be OVSREQUIRES).

Fixes #199.