### PR TITLE
Issue #211 - Add support for vrf in Cumulus Linux

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -304,6 +304,10 @@ define network::interface (
   $pre_down              = [ ],
   $post_down             = [ ],
 
+  # For virtual routing and forwarding (VRF)
+  $vrf                   = undef,
+  $vrf_table             = undef,
+
   # For bonding
   $slaves                = [ ],
   $bond_mode             = undef,

--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -262,6 +262,12 @@ allow-hotplug <%= @interface %>
 <% if @wpa_ap_scan -%>
     wpa-ap-scan <%= @wpa_ap_scan %>
 <% end -%>
+<% if @vrf -%>
+    vrf <%= @vrf %>
+<% end -%>
+<% if @vrf_table -%>
+    vrf-table <%= @vrf_table %>
+<% end -%>
 <% if @aliases -%>
 <% if @aliases.is_a? Array -%>
 <% @aliases.each_with_index do |val, idx| %>


### PR DESCRIPTION
These changes will enable the creation of VRFs on supported distributions (namely Cumulus Linux 3 series) as described in issue #211 