### PR TITLE
Issue #213 - Enable IPv6 route creation on RedHat based systems

### DIFF
--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -27,7 +27,7 @@
 # === Actions:
 #
 # On Rhel
-# Deploys the file /etc/sysconfig/network-scripts/route-$name.
+# Deploys 2 files under/etc/sysconfig/network-scripts/, route-$name and route6-$name
 #
 # On Debian
 # Deploy 2 files 1 under /etc/network/if-up.d and 1 in /etc/network/if-down.d
@@ -41,10 +41,14 @@
 #   }
 #
 #   network::route { 'bond2':
-#     ipaddress => [ '192.168.2.0', '10.0.0.0', ],
-#     netmask   => [ '255.255.255.0', '255.0.0.0', ],
-#     gateway   => [ '192.168.1.1', '10.0.0.1', ],
+#     ipaddress => [ '192.168.2.0', '10.0.0.0', '::', ],
+#     netmask   => [ '255.255.255.0', '255.0.0.0', '0', ],
+#     gateway   => [ '192.168.1.1', '10.0.0.1', 'fd00::1', ],
+#     family    => [ 'inet4', 'inet4', 'inet6', ],
 #   }
+#
+# Note that for the familiy parameter, everything else than "inet6" will be written
+# as an IPv4 route.
 #
 # A routing table can also be specified for the route:
 #
@@ -147,6 +151,15 @@ define network::route (
         group   => 'root',
         path    => "/etc/sysconfig/network-scripts/route-${name}",
         content => template('network/route-RedHat.erb'),
+        notify  => $network::manage_config_file_notify,
+      }
+      file { "route6-${name}":
+        ensure  => $ensure,
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+        path    => "/etc/sysconfig/network-scripts/route6-${name}",
+        content => template('network/route6-RedHat.erb'),
         notify  => $network::manage_config_file_notify,
       }
     }

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -108,7 +108,7 @@ define network::route (
   $scope     = undef,
   $source    = undef,
   $table     = undef,
-  $family    = undef,
+  $family    = [ 'inet4' ],
   $interface = $name,
   $ensure    = 'present'
 ) {

--- a/templates/route-RedHat.erb
+++ b/templates/route-RedHat.erb
@@ -2,5 +2,5 @@
 ### File managed by Puppet
 ###
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-<%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
+<%- if @family and @family[id] != 'inet6' -%><%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %><%- end -%>
 <%- end %>

--- a/templates/route-RedHat.erb
+++ b/templates/route-RedHat.erb
@@ -2,5 +2,5 @@
 ### File managed by Puppet
 ###
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-<%- if @family and @family[id] != 'inet6' -%><%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %><%- end -%>
-<%- end %>
+<%- if @family and @family[id] != 'inet6' -%><%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
+<%- end -%><%- end %>

--- a/templates/route6-RedHat.erb
+++ b/templates/route6-RedHat.erb
@@ -2,5 +2,5 @@
 ### File managed by Puppet
 ###
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-<%- if @family and @family[id] == 'inet6' -%><%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %><%- end -%>
-<%- end %>
+<%- if @family and @family[id] == 'inet6' -%><%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
+<%- end -%><%- end %>

--- a/templates/route6-RedHat.erb
+++ b/templates/route6-RedHat.erb
@@ -1,0 +1,6 @@
+###
+### File managed by Puppet
+###
+<%- (0..(@ipaddress.length-1)).each do |id| -%>
+<%- if @family and @family[id] == 'inet6' -%><%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %><%- end -%>
+<%- end %>


### PR DESCRIPTION
These changes enables the creation of IPv6 routes as described in issue #213.

In short, on RedHat based systems, two route files will now be created instead of one. While this is not optimal (one would suffice if only one address family is specified for the routes), it is the easiest way out while maintaining compatibility with the existing "family" parameter. The difference between debian and RedHat based systems is that on debian, IPv4 and IPv6 based routes are written to the same files, while RedHat demands the routes written in route-${name} and route6-${name}, respectively. The potentially empty route files are not a problem as such, they do not create error messages or any sort of problems, it would just be nice to avoid it, but I cannot see a good way to accomplish that while adhering to already existing functionality.

