### PR TITLE
bugfix for issue #235: Change HWADDR in interface/RedHat.erb to MACADDR

### DIFF
--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -79,7 +79,7 @@ GATEWAY="<%= @gateway %>"
 DEFROUTE="<%= @manage_defroute %>"
 <% end -%>
 <% if @manage_hwaddr -%>
-HWADDR="<%= @manage_hwaddr %>"
+MACADDR="<%= @manage_hwaddr %>"
 <% end -%>
 <% if @ipv6init -%>
 IPV6INIT="<%= @ipv6init %>"


### PR DESCRIPTION
Intended behaviour of manage_hwaddr variable is to change device's MAC address.
HWADDR variable in Redhat scripts is used for checking MAC, not setting it.
To change device's MAC you need to set MACADDR variable.
Check https://www.centos.org/docs/5/html/Deployment_Guide-en-US/s1-networkscripts-interfaces.html

