### PR TITLE
#239 Fix incorrect variable names

### DIFF
--- a/spec/defines/network_interface_spec.rb
+++ b/spec/defines/network_interface_spec.rb
@@ -8,8 +8,11 @@ describe 'network::interface' do
     let(:node) { 'rspec.example42.com' }
     let(:facts) { { :architecture => 'x86_64', :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
     let(:params) {
-      { 'enable'       =>  true,
-        'ipaddress'    =>  '10.42.42.42',
+      { 'enable'                =>  true,
+        'ipaddress'             =>  '10.42.42.42',
+        'options_extra_redhat'  => {
+          'IPV4_FAILURE_FATAL'  => 'yes',
+        },
       }
     }
 
@@ -23,6 +26,10 @@ describe 'network::interface' do
 
     it {
       is_expected.to contain_file('/etc/sysconfig/network-scripts/ifcfg-eth0').with_content(/ONBOOT=\"yes\"/)
+    }
+
+    it {
+      is_expected.to contain_file('/etc/sysconfig/network-scripts/ifcfg-eth0').with_content(/IPV4_FAILURE_FATAL=\"yes\"/)
     }
 
   end

--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -314,8 +314,8 @@ auto <%= @interface %>:0
     netmask 255.255.255.255
 <% end -%>
 <% end -%>
-<% if @extra_options_debian -%>
-<% @extra_options_debian.each do |k,v| -%>
+<% if @options_extra_debian -%>
+<% @options_extra_debian.each do |k,v| -%>
     <%= k %> <%= v %>
 <% end -%>
 <% end -%>

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -223,8 +223,8 @@ OVSREQUIRES="<%= @ovsrequires %>"
 <% if @nm_name -%>
 NAME="<%= @nm_name %>"
 <% end -%>
-<% if @extra_options_redhat -%>
-<% @extra_options_redhat.each do |k,v| -%>
+<% if @options_extra_redhat -%>
+<% @options_extra_redhat.each do |k,v| -%>
 <%= k %>="<%= v %>"
 <% end -%>
 <% end -%>

--- a/templates/interface/Suse.erb
+++ b/templates/interface/Suse.erb
@@ -95,8 +95,8 @@ PRE_DOWN_SCRIPT="<%= @pre_down_script %>"
 <% if @post_down_script -%>
 POST_DOWN_SCRIPT="<%= @post_down_script %>"
 <% end -%>
-<% if @extra_options_suse -%>
-<% @extra_options_suse.each do |k,v| -%>
+<% if @options_extra_suse -%>
+<% @options_extra_suse.each do |k,v| -%>
 <%= k %>="<%= v %>"
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This fix corrects the name of variables within the NIC config files.
Without this fix `extra` options for the three valid operating systems
is not possible.

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

