### PR TITLE
(#250) Use _cidr variable to generate routing config on EL

### DIFF
--- a/templates/route-RedHat.erb
+++ b/templates/route-RedHat.erb
@@ -2,5 +2,5 @@
 ### File managed by Puppet
 ###
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-<%- if @family and @family[id] != 'inet6' -%><%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %><%- if @mtu and @mtu[id] -%> mtu <%= @mtu[id] %><% end %>
+<%- if @family and @family[id] != 'inet6' -%><%= @ipaddress[id] %>/<%= @_cidr[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %><%- if @mtu and @mtu[id] -%> mtu <%= @mtu[id] %><% end %>
 <%- end -%><%- end %>

--- a/templates/route6-RedHat.erb
+++ b/templates/route6-RedHat.erb
@@ -2,5 +2,5 @@
 ### File managed by Puppet
 ###
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-<%- if @family and @family[id] == 'inet6' -%><%= @ipaddress[id] %>/<%= @netmask[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
+<%- if @family and @family[id] == 'inet6' -%><%= @ipaddress[id] %>/<%= @_cidr[id] %><%- if @gateway and @gateway[id] -%> via <%= @gateway[id] %><%- end -%> dev <%= @interface %><%- if @scope and @scope[id] -%> scope <%= @scope[id] %><%- end -%><%- if @source and @source[id] -%> src <%= @source[id] %><%- end -%><%- if @table and @table[id] -%> table <%= @table[id] %><% end %><%- if @metric and @metric[id] -%> metric <%= @metric[id] %><% end %>
 <%- end -%><%- end %>


### PR DESCRIPTION
With NetworkManager >=1.10, it is no longer valid to specify a routing
with a netmask, e.g. "192.168.1.0/255.255.255.0".
NetworkManager now requires the CIDR notation, e.g. "192.168.1.0/24".

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

