### PR TITLE
Fix prefix option in template

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -544,6 +544,10 @@ define network::interface (
     fail('CONNECTED_MODE parameter available for InfiniBand interfaces only')
   }
 
+  if $prefix != undef and $netmask != undef {
+    fail('Use either netmask or prefix to define the netmask for the interface')
+  }
+
   $manage_hwaddr = $hwaddr ? {
     default => $hwaddr,
   }

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -64,9 +64,9 @@ NETMASK<%= id %>="<%= @netmask %>"
 <% else -%>
 NETMASK="<%= @netmask %>"
 <% end -%>
+<% end -%>
 <% if @prefix -%>
 PREFIX="<%= @prefix %>"
-<% end -%>
 <% end -%>
 <% if @broadcast -%>
 BROADCAST="<%= @broadcast %>"


### PR DESCRIPTION
Previously the prefix print statement was wongly position and would
never print out actually as it was in the netmask if. This is now fixed;
netmask and prefix are independant.
Additionally a guard clause was added to make sure that netmask is not
set when prefix is set.

This prefix fixes #269.