### PR TITLE
params: Adapt service restart for RHEL 8. fixes #296

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,10 @@ class network::params {
   $service_restart_exec = $::osfamily ? {
     'Debian'  => '/sbin/ifdown -a --force ; /sbin/ifup -a',
     'Solaris' => '/usr/sbin/svcadm restart svc:/network/physical:default',
+    'RedHat'  => versioncmp($facts['os']['release']['major'], '8') ? {
+      -1      => 'service network restart',
+      default => 'nmcli networking off && nmcli networking on',
+    },
     default   => 'service network restart',
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class network::params {
     'Solaris' => '/usr/sbin/svcadm restart svc:/network/physical:default',
     'RedHat'  => versioncmp($facts['os']['release']['major'], '8') ? {
       -1      => 'service network restart',
-      default => 'nmcli networking off && nmcli networking on',
+      default => 'nmcli connection reload && nmcli networking off && nmcli networking on',
     },
     default   => 'service network restart',
   }


### PR DESCRIPTION
The classic network service is gone,
restarting NetworkManager.service will not apply
all changes if interfaces are already up.
Our only option is to reactivate all devices:
```
nmcli networking off && nmcli networking on
```
fixes #296