### PR TITLE
Debian: avoid misconfigured interfaces on up/down script errors

### DIFF
--- a/templates/interface/Debian.erb
+++ b/templates/interface/Debian.erb
@@ -1,3 +1,4 @@
+# File Managed by Puppet
 # Interface <%= @name %>
 <% if @description and ! @description.empty? -%>
 # <%= @description %>

--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -10,3 +10,5 @@ if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
   fi
 <%- end -%>
 fi
+# non-zero exit code causes ifupdown to leave the interface partly configured, which may result in connectivity loss
+exit 0

--- a/templates/route_up-Debian.erb
+++ b/templates/route_up-Debian.erb
@@ -10,3 +10,5 @@ if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
   fi
 <%- end -%>
 fi
+# non-zero exit code causes ifupdown to leave the interface partly configured, which may result in connectivity loss
+exit 0

--- a/templates/rule_down-Debian.erb
+++ b/templates/rule_down-Debian.erb
@@ -10,3 +10,5 @@ if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
   fi
 <%- end -%>
 fi
+# non-zero exit code causes ifupdown to leave the interface partly configured, which may result in connectivity loss
+exit 0

--- a/templates/rule_up-Debian.erb
+++ b/templates/rule_up-Debian.erb
@@ -10,3 +10,5 @@ if [ "$IFACE" = "<%= @interface -%>" ] || [ "$IFACE" = "--all" ]; then
   fi
 <%- end -%>
 fi
+# non-zero exit code causes ifupdown to leave the interface partly configured, which may result in connectivity loss
+exit 0


### PR DESCRIPTION
In Debian, if you bring up dual-stack interfaces, the pre/post-up/down
scripts are run on the configuration of each stack. I.e. if you bring up
the IPv4 config on an interface, the ifupdown scripts launch scripts in
the post-up directory. These scripts are common for IPv4 and IPv6 in current
version of puppet-network. At the moment IPv6 is not yet configured, but
IPv6 commands are called - and fail. If an IPv6 command (e.g. `ip -6 route add`)
is the last one in the post-up script, the overall post-up script fails.

When the post-up script fails when bringing up the IPv4 configuration,
ifupdown no longer attempts to bring up the IPv6 configuration on that
interface and leaves the interface misconfigured (IPv4 is configured,
IPv6 is not).

This situation can be avoided by adding the `exit 0` command at the very
end of the script files. It is okay if the IPv6 commands in the common script
fail when only IPv4 is brought up, as ifupdown will re-run them after
IPv6 is brought up.

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

