### PR TITLE
Add default family = ['inet4',] for network::rule (issue 318)

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -28,7 +28,7 @@
 define network::rule (
   $iprule,
   $interface = $name,
-  $family    = undef,
+  $family    = ['inet4',],
   $ensure    = 'present'
 ) {
   # Validate our arrays


### PR DESCRIPTION
## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

