### PR TITLE
added RH ipv6 general params, kept backward compatible with ipv6enable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,12 @@ class network (
   $gateway                   = undef,
   $nozeroconf                = undef,
   $ipv6enable                = undef,
+  $networking_ipv6           = undef,
+  $ipv6forwarding            = undef,
   $ipv6_autoconf             = undef,
+  $ipv6_autotunnel           = undef,
+  $ipv6_defaultgw            = undef,
+  $ipv6_radvd_pidfile        = undef,
 
   # Stdmod commons
   $package_name              = $::network::params::package_name,
@@ -231,6 +236,39 @@ class network (
     $config_file_ensure = present
   }
 
+  $manage_networking_ipv6 = $networking_ipv6 ? {
+    'yes'   => 'yes',
+    'no'    => 'no',
+    default => undef,
+  }
+  $manage_ipv6forwarding = $ipv6forwarding ? {
+    'yes'   => 'yes',
+    'no'    => 'no',
+    default => undef,
+  }
+  $manage_ipv6_autoconf = $ipv6_autoconf ? {
+    'yes'   => 'yes',
+    'no'    => 'no',
+    default => undef,
+  }
+  $manage_ipv6_autotunnel = $ipv6_autotunnel ? {
+    'yes'   => 'yes',
+    'no'    => 'no',
+    default => undef,
+  }
+  if $ipv6_defaultgw {
+    if $ipv6_defaultgw =~ Stdlib::IP::Address::V6 {
+      $manage_ipv6_defaultgw = $ipv6_defaultgw
+    } else {
+      notify {"wrong IPv6 default gateway address: $ipv6_defaultgw":}
+      err ("wrong IPv6 default gateway address: $ipv6_defaultgw")
+    }
+  }
+  if $ipv6_radvd_pidfile =~ Stdlib::Absolutepath {
+    $manage_ipv6_radvd_pidfile = $ipv6_radvd_pidfile
+  } else {
+    $manage_ipv6_radvd_pidfile = undef
+  }
 
   # Dependency class
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -260,8 +260,8 @@ class network (
     if $ipv6_defaultgw =~ Stdlib::IP::Address::V6 {
       $manage_ipv6_defaultgw = $ipv6_defaultgw
     } else {
-      notify {"wrong IPv6 default gateway address: $ipv6_defaultgw":}
-      err ("wrong IPv6 default gateway address: $ipv6_defaultgw")
+      notify {"wrong IPv6 default gateway address: ${ipv6_defaultgw}":}
+      err ("wrong IPv6 default gateway address: ${ipv6_defaultgw}")
     }
   }
   if $ipv6_radvd_pidfile =~ Stdlib::Absolutepath {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,14 +256,9 @@ class network (
     'no'    => 'no',
     default => undef,
   }
-  if $ipv6_defaultgw {
-    if $ipv6_defaultgw =~ Stdlib::IP::Address::V6 {
-      $manage_ipv6_defaultgw = $ipv6_defaultgw
-    } else {
-      notify {"wrong IPv6 default gateway address: ${ipv6_defaultgw}":}
-      err ("wrong IPv6 default gateway address: ${ipv6_defaultgw}")
-    }
-  }
+  
+  $manage_ipv6_defaultgw = $ipv6_defaultgw
+  
   if $ipv6_radvd_pidfile =~ Stdlib::Absolutepath {
     $manage_ipv6_radvd_pidfile = $ipv6_radvd_pidfile
   } else {

--- a/templates/hostname-RedHat.erb
+++ b/templates/hostname-RedHat.erb
@@ -9,9 +9,24 @@ NOZEROCONF="<%= @nozeroconf %>"
 <% if @ipv6enable -%>
 NETWORKING_IPV6="<%= @ipv6enable %>"
 IPV6INIT="<%= @ipv6enable %>"
-<% if @ipv6_autoconf -%>
-IPV6_AUTOCONF="<%= @ipv6_autoconf %>"
 <% end -%>
+<% if @manage_networking_ipv6 -%>
+NETWORKING_IPV6="<%= @manage_networking_ipv6 %>"
+<% end -%>
+<% if @manage_ipv6forwarding -%>
+IPV6FORWARDING="<%= @manage_ipv6forwarding %>"
+<% end -%>
+<% if @manage_ipv6_autoconf -%>
+IPV6_AUTOCONF="<%= @manage_ipv6_autoconf %>"
+<% end -%>
+<% if @manage_ipv6_autotunnel -%>
+IPV6_AUTOTUNNEL="<%= @manage_ipv6_autotunnel %>"
+<% end -%>
+<% if @manage_ipv6_defaultgw -%>
+IPV6_DEFAULTGW="<%= @manage_ipv6_defaultgw %>"
+<% end -%>
+<% if @manage_ipv6_radvd_pidfile -%>
+IPV6_RADVD_PIDFILE="<%= @manage_ipv6_radvd_pidfile %>"
 <% end -%>
 <% if @hostname -%>HOSTNAME="<%= @hostname %>"
 <%- else %>HOSTNAME="<%= @manage_hostname.split('.').first %>"


### PR DESCRIPTION
Added common parameters for RH ipv6  (placed in /etc/sysconfig/network)

Mostly we were in need for ipv6_defaultgw but we did for all parameters we know can be present. 

Parameters are validated for yes/no values.
ipv6_defaultgw verified to be ipv6 address.
ipv6_radvd_pidfile verified to be filepath

IPV6_AUTOCONF was moved to the block not controlled by ipv6enable. 

ipv6enable kept for backward compatibility but if glues together: NETWORKING_IPV6 that is global and IPV6INIT that is more per interface parameter. Can't find a good documentation on it.  

