### PR TITLE
adding PREFIX= for RH. Adding CIDR ipv4 address format for RH

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -282,7 +282,6 @@ define network::interface (
   $enable_dhcp           = false,
 
   $ipaddress             = '',
-  $prefix                = undef,
   $netmask               = undef,
   $network               = undef,
   $broadcast             = undef,

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -282,6 +282,7 @@ define network::interface (
   $enable_dhcp           = false,
 
   $ipaddress             = '',
+  $prefix                = undef,
   $netmask               = undef,
   $network               = undef,
   $broadcast             = undef,
@@ -634,9 +635,17 @@ define network::interface (
     },
     default => $peerntp,
   }
-  $manage_ipaddr = $ipaddr ? {
-    ''      => $ipaddress,
-    default => $ipaddr,
+  case $ipaddr {
+    '': { $manage_ipaddr = $ipaddress}
+    default: {
+      if $ipaddr =~ /^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\/([0-9]|[1-2][0-9]|3[0-2])$/ {
+        $manage_ipaddr = $1
+        $manage_prefix = $2
+      } else {
+        $manage_ipaddr = $ipaddr
+        $manage_prefix = $prefix
+      }
+    }
   }
   $manage_onboot = $onboot ? {
     ''     => $enable ? {

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -80,9 +80,6 @@ NETMASK<%= id %>="<%= @netmask %>"
 NETMASK="<%= @netmask %>"
 <% end -%>
 <% end -%>
-<% if @prefix -%>
-PREFIX="<%= @prefix %>"
-<% end -%>
 <% if @broadcast -%>
 BROADCAST="<%= @broadcast %>"
 <% end -%>

--- a/templates/interface/RedHat.erb
+++ b/templates/interface/RedHat.erb
@@ -50,6 +50,21 @@ IPADDR<%= id %>="<%= @ipaddress[id-1] %>"
 IPADDR="<%= @manage_ipaddr %>"
 <% end -%>
 <% end -%>
+<% if @manage_prefix -%>
+<% if @ipaddress.kind_of?(Array) -%>
+<% if @manage_prefix.kind_of?(Array) -%>
+<%- (1..(@manage_prefix.length)).each do |id| -%>
+PREFIX<%= id %>="<%= @manage_prefix[id-1] %>"
+<% end -%>
+<% else -%>
+<%- (1..(@ipaddress.length)).each do |id| -%>
+PREFIX<%= id %>="<%= @manage_prefix %>"
+<% end -%>
+<% end -%>
+<% else -%>
+PREFIX="<%= @manage_prefix %>"
+<% end -%>
+<% end -%>
 <% if @netmask -%>
 <% if @ipaddress.kind_of?(Array) -%>
 <% if @netmask.kind_of?(Array) -%>


### PR DESCRIPTION
added PREFIX= handling for RH interfaces.

Tired to write netmask broadcast network parameters while all linux commands understand CIDR format
So, added CIDR format IPv4 addresses for RH:
 - if ipaddr match CIDR regex it will be translated into IPADDR= PREFIX= pair.
 - if ipaddr don't match nothing will be changed keeping back compatibility
 - prefix parameter added as is.

I kept same logic for ipaddr and ipaddress choice. Logic above applies for ipaddr, ipaddress will pass intact. Let me know if need another implementation?



I was not able to test with multiple addresses, i can see it in ERB but was not able to use it:


ipaddr: ['xxx','xxx']          - results in   IPADDR=['xxx','xxx']
ipaddr:                          - results in no IPADDR set 
    \- xxx
    \- xxx 

 
But i've added PREFIX= handling assuming it can also be array in the ERB same way as it was done for netmask to keep maximum compatibility. 


