### PR TITLE
Reload NM configs before reapplying (#337)

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -683,7 +683,7 @@ define network::interface (
     undef => $::operatingsystem ? {
         'CumulusLinux' => 'ifreload -a',
         'RedHat'       => $::operatingsystemmajrelease ? {
-          '8'     => "/usr/bin/nmcli device reapply ${interface}",
+          '8'     => "/usr/bin/nmcli con reload ; /usr/bin/nmcli device reapply ${interface}",
           default => "ifdown ${interface} --force ; ifup ${interface}",
         },
         default        => "ifdown ${interface} --force ; ifup ${interface}",


### PR DESCRIPTION
Pull request as requested.  Changes real_reload_command to run 'nmcli con reload' before 'nmcli device reapply ${interface}' since NetworkManager won't detect the underlying file changes otherwise.