### PR TITLE
#342: Allow substring hostname

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -358,7 +358,7 @@ class network (
       '7','8': {
         exec { 'sethostname':
           command => "/usr/bin/hostnamectl set-hostname ${manage_hostname}",
-          unless  => "/usr/bin/hostnamectl status | grep 'Static hostname: ${manage_hostname}'",
+          unless  => "/usr/bin/hostnamectl status | grep 'Static hostname: ${manage_hostname}$'",
         }
       }
       default: {}


### PR DESCRIPTION
Let's say the current hostname is 'aaabbbccc'. The current module won't
allow you to change to, for instance, 'aaabbb' since it can grep
'aaabbb' from 'aaabbbccc'.

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

