### PR TITLE
Bugfix: remove duplicate definition for Exec[network_restart_${name}]

### DIFF
--- a/manifests/mroute.pp
+++ b/manifests/mroute.pp
@@ -98,12 +98,12 @@ define network::mroute (
     default => $reload_command,
   }
   if $restart_all_nic == false and $::kernel == 'Linux' {
-    exec { "network_restart_${name}":
+    exec { "network_restart_route_${name}":
       command     => $real_reload_command,
       path        => '/sbin:/bin:/usr/sbin:/usr/bin',
       refreshonly => true,
     }
-    $network_notify = "Exec[network_restart_${name}]"
+    $network_notify = "Exec[network_restart_route_${name}]"
   } else {
     $network_notify = $network::manage_config_file_notify
   }


### PR DESCRIPTION
if network::interface and network::mroute is used for the same
interface, and $restart_all_nics is false, the definition for
network_restart will be duplicated, using puppet to fail.

if you use
  network::mroute { 'static-eth0':
    interface => 'eth0'
    ...
  }
puppet will not complain, but create a "route-static-eth0"-file which
will not be pickuped by networkmanager.

So either move the exec-definition into a separate file (and use it from
with the interface.pp and mroute.pp manifest), or check if the
exec-definition was already defined, or (the way I choosed for now) use
a different name for the exec-ressource.

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

