### PR TITLE
Fixes #344

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -310,9 +310,8 @@ class network (
   }
 
   # Command that triggers network restart
-  exec { $service_restart_exec :
+  exec { 'network_restart' :
     command     => $service_restart_exec,
-    alias       => 'network_restart',
     refreshonly => true,
     path        => '/bin:/sbin:/usr/bin:/usr/sbin',
   }

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -759,10 +759,9 @@ define network::interface (
       } else {
         if ! defined(Concat['/etc/network/interfaces']) {
           concat { '/etc/network/interfaces':
-            mode   => '0644',
-            owner  => 'root',
-            group  => 'root',
-            notify => $network_notify,
+            mode  => '0644',
+            owner => 'root',
+            group => 'root',
           }
         }
 
@@ -772,13 +771,19 @@ define network::interface (
           order   => $manage_order,
         }
 
+        if $restart_all_nic == true and $network::manage_config_file_notify != undef {
+          Concat['/etc/network/interfaces'] ~> Exec['network_restart']
+        } else {
+          Concat['/etc/network/interfaces'] ~> Exec <| title == "network_restart_${name}" |>
+        }
       }
 
       if ! defined(Network::Interface['lo']) {
         network::interface { 'lo':
-          address      => '127.0.0.1',
-          method       => 'loopback',
-          manage_order => '05',
+          address         => '127.0.0.1',
+          method          => 'loopback',
+          manage_order    => '05',
+          restart_all_nic => $restart_all_nic,
         }
       }
     }


### PR DESCRIPTION
Fixes #344

Bugfix: on Debian, when restart_all_nic parameter is set to false it will restart the interface if it has a configuration change